### PR TITLE
Example language clarification & Preview removal

### DIFF
--- a/well-architected/warp/warp-guidance.md
+++ b/well-architected/warp/warp-guidance.md
@@ -43,9 +43,9 @@ The goal of this stage is to establish a backlog of work items either through a 
 > [!NOTE]
 > The [Microsoft Cloud Adoption Framework for Azure](/azure/cloud-adoption-framework/overview) is proven guidance that's designed to help you create and implement the business and technology strategies necessary for your organization to succeed in the cloud. This guidance can help you define the [cloud operating model](/azure/cloud-adoption-framework/operating-model/) that governs the operational process for your workload.
 
-If you're using a [DevOps](/azure/cloud-adoption-framework/ready/enterprise-scale/platform-automation-and-devops#planning-for-a-devops-approach) approach for your operational process, Microsoft has provided example tooling that will automate the import of the recommendations from the Well-Architected Review exported CSV into a new [Azure DevOps](/azure/devops) or [GitHub](https://azure.microsoft.com/products/github/#overview) project within your existing organization.
+If you're using a [DevOps](/azure/cloud-adoption-framework/ready/enterprise-scale/platform-automation-and-devops#planning-for-a-devops-approach) approach for your operational process, Microsoft has provided example scripts that will automate the import of the recommendations from the Well-Architected Review exported CSV into a new [Azure DevOps](/azure/devops) or [GitHub](https://azure.microsoft.com/products/github/#overview) project within your existing organization.
 
-Download the automated import tool at [DevOps Tooling for Well-Architected Recommendation Process](https://github.com/Azure/WellArchitected-Tools/tree/main/WARP/devops#readme).
+Download example import scripts at [DevOps Tooling for Well-Architected Recommendation Process](https://github.com/Azure/WellArchitected-Tools/tree/main/WARP/devops#readme).
 
 ## Triage backlog
 

--- a/well-architected/warp/warp-guidance.md
+++ b/well-architected/warp/warp-guidance.md
@@ -21,7 +21,7 @@ categories:
   - management-and-governance
 ---
 
-# Well-Architected Recommendation Process Guidance (Preview)
+# Well-Architected Recommendation Process Guidance
 
 ## Overview
 


### PR DESCRIPTION
Updating language to more clearly indicate import automation options are example scripts, not a supported tool.
Also removed 'Preview' from title of the process