### PR TITLE
Update of OpEx principles and some other changes

### DIFF
--- a/well-architected/TOC.yml
+++ b/well-architected/TOC.yml
@@ -269,6 +269,8 @@ items:
                 href: devops/checklist.md
               - name: Monitor cloud applications
                 items:
+                  - name: Monitoring Overview
+                    href: devops/monitoring.md
                   - name: Monitoring stages
                     href: devops/monitor-pipeline.md
                   - name: Data sources

--- a/well-architected/devops/monitor-pipeline.md
+++ b/well-architected/devops/monitor-pipeline.md
@@ -3,7 +3,7 @@ title: Monitoring workloads
 description: Set up a pipe to collect, store, analyze, and visualize data for monitoring and diagnostics. 
 author: PageWriter-MSFT
 ms.author: robbymillsap
-ms.date: 12/08/2021
+ms.date: 03/03/2022
 ms.topic: conceptual
 ms.service: architecture-center
 ms.subservice: well-architected

--- a/well-architected/devops/monitoring.md
+++ b/well-architected/devops/monitoring.md
@@ -3,7 +3,7 @@ title: Monitoring for Workloads
 description: Understand how to monitor your workload to make sure your DevOps infrastructure is working as intended.
 author: david-stanford
 ms.author: robbymillsap
-ms.date: 12/08/2021
+ms.date: 03/03/2022
 ms.topic: conceptual
 ms.service: architecture-center
 ms.subservice: well-architected

--- a/well-architected/devops/overview.md
+++ b/well-architected/devops/overview.md
@@ -3,7 +3,7 @@ title: Overview of the operational excellence pillar
 description: Understand the operational excellence pillar, which covers the operations processes that keep an application running in production.
 ms.author: robbymillsap
 author: david-stanford
-ms.date: 12/07/2021
+ms.date: 03/03/2022
 ms.topic: conceptual
 ms.service: architecture-center
 ms.subservice: well-architected
@@ -18,7 +18,7 @@ categories:
 
 # Overview of the operational excellence pillar
 
-The operational excellence pillar covers the operations processes that keep an application running in production. Deployments must be reliable and predictable. Automated deployments reduce the chance of human error. Fast and routine deployment processes won't slow down the release of new features or bug fixes. Equally important, you must be able to quickly roll back or roll forward if an update has problems.
+The operational excellence pillar covers the operations processes that keep a workload running in production. Deployments must be reliable and predictable. Automated deployments reduce the chance of human error. Fast and routine deployment processes won't slow down the release of new features or bug fixes. Equally important, you must be able to quickly roll back or roll forward if an update has problems.
 
 To assess your workload using the tenets found in the [Microsoft Azure Well-Architected Framework](/azure/architecture/framework/), reference the [Microsoft Azure Well-Architected Review](/assessments/?id=azure-architecture-review&mode=pre-assessment).
 
@@ -37,27 +37,13 @@ The Microsoft Azure Well-Architected Framework includes the following topics in 
 | Operational excellence topics | Description |
 |-------------------|-------------|
 | [Application design][app-design] | Provides guidance on how to design, build, and orchestrate workloads with DevOps principles in mind.  |
-| [Monitoring][monitoring] | Something that enterprises have been doing for years, enriched with specifics for applications running in the cloud. |
-| [Application performance management][performance] | The monitoring and management of performance, and availability of software applications through DevOps. |
+| [Monitoring][monitoring] | Monitoring helps ensure that a workload performs as expected. Best practices around monitoring help ensure observability as cloud deployments grow. |
+| [Application performance management][performance] | This discipline applies DevOps practices to manage application performance and availablity. |
 | [Code deployment][deployment] | How you deploy your application code is one of the key factors that determines your application stability.  |
-| [Infrastructure provisioning][iac] | Frequently known as *Automation* or *Infrastructure as code*, this discipline refers to best practices for deploying the platform where your application will run. |
+| [Infrastructure provisioning][iac] | Frequently referred to as *Infrastructure as code*, this discipline refers to best practices for deploying the platform where your application will run. |
 | [Testing][testing] | Testing is fundamental to prepare for the unexpected and to catch mistakes before they impact users. |
-
-Monitoring and diagnostics are crucial. Cloud applications run in a remote data-center where you don't have full control of the infrastructure or, in some cases, the operating system. In a large application, it's not practical to log into virtual machines (VMs) to troubleshoot an issue or sift through log files. With PaaS services, there may not be a dedicated VM to log into. Monitoring and diagnostics give insight into the system, so that you know when and where failures occur. All systems must be observable. Use a common and consistent logging schema that lets you correlate events across systems.
-
-The monitoring and diagnostics process has several distinct phases:
-
-- *Instrumentation*: Generating the raw data from:
-  - application logs
-  - web server logs
-  - diagnostics built into the Azure platform, and other sources.
-- *Collection and storage*: Consolidating the data into one place.
-- *Analysis and diagnosis*: To troubleshoot issues and see the overall health.
-- *Visualization and alerts*: Using telemetry data to spot trends or alert the operations team.
-
-Enforcing resource-level rules through [Azure Policy](/azure/governance/policy/overview) helps ensure adoption of operational excellence best practices for all the assets, which support your workload. For example, Azure Policy can help ensure all the VMs supporting your workload adhere to a pre-approved list of VM SKUs. Azure Advisor provides [a set of Azure Policy recommendations](/azure/advisor/advisor-operational-excellence-recommendations#use-azure-policy-recommendations) to help you quickly identify opportunities to implement Azure Policy best practices for your workload.
-
-Use the [DevOps checklist][devops-checklist] to review your design from a management and DevOps standpoint.
+| [Azure Policy](/azure/governance/policy/overview) | Enforcing resource-level rules through Azure Policy helps ensure adoption of operational excellence best practices for all the assets, which support your workload. Azure Advisor provides [a set of Azure Policy recommendations](/azure/advisor/advisor-operational-excellence-recommendations#use-azure-policy-recommendations) to help you quickly identify opportunities to implement Azure Policy best practices for your workload.
+| [DevOps checklist][devops-checklist] | Use the DevOps checklist to review your design from a management and DevOps standpoint.
 
 ## Next steps
 

--- a/well-architected/devops/principles.md
+++ b/well-architected/devops/principles.md
@@ -3,7 +3,7 @@ title: Operational excellence design principles
 description: Understand the design principles for operational excellence within the Azure Well-Architected Framework.
 author: david-stanford
 ms.author: robbymillsap
-ms.date: 02/10/2022
+ms.date: 03/03/2022
 ms.topic: conceptual
 ms.service: architecture-center
 ms.subservice: well-architected
@@ -11,7 +11,7 @@ ms.subservice: well-architected
 
 # Operational excellence design principles
 
-The principles of operational excellence are a series of considerations that can help achieve superior operational practices.
+The operational excellence design principles are a series of considerations that can help achieve superior operational practices.
 
 To achieve a higher competency in operations, consider and improve how software is:
 
@@ -20,83 +20,75 @@ To achieve a higher competency in operations, consider and improve how software 
 - Operated
 - Maintained
 
-Equally important, provide a team culture, which includes:
+Equally important, foster a team culture, which...
 
-- Experimentation and growth
-- Solutions for rationalizing the current state of operations
-- Incident response plans
+- values those who find solutions for rationalizing the current state of operations
+- provides accurate and targeted responses to incidents 
+- commits to continuous learning, ongoing experimentation, and growth
 
 To assess your workload using the tenets found in the Azure Well-Architected Framework, reference the [Microsoft Azure Well-Architected Review](/assessments/?id=azure-architecture-review&mode=pre-assessment).
 
 The following design principles provide:
 
-- Context for questions
-- Why a certain aspect is important
-- How an aspect is applicable to Operational excellence
+- Context for the questions in the Well-Architected Review
+- Reasons why a certain aspect is important
+- Explanations of how particular aspects apply to operational excellence
 
-These critical design principles are used as lenses to assess the Operational excellence of an application deployed on Azure. These lenses provide a framework for the application assessment questions.
+These critical design principles are used as lenses through which the operational excellence of an application deployed on Azure is assessed.
 
-## Optimize build and release processes
+## Maximize automation
 
-Embrace software engineering disciplines across your entire environment, which include the following disciplines:
+Adopt and apply modern DevOps practices like continuous integration/continuous delivery (CI/CD), automated testing, infrastructure as code (IaC) and configuration as code to support cloud workloads.
   
-- Provision with Infrastructure as Code
-- Build and release with continuous integration and continuous delivery (CI/CD) pipelines
-- Automated testing
+This approach ensures consistent creation and management of environments throughout the software development lifecycle and encourages teams to practice deployments often. This - in turn - gives them an opportunity to detect issues early.
+
+## Maximize continuous improvement efforts
+
+Embrace and foster continuous improvement culture to evolve business processes, reduce complexity, and eliminate inefficiencies as much as possible.
+
+An organization that models a continuous improvement culture has teams that...
+- periodically evaluate new technology
+- share learning from failure
+- suggest improvements business processes
+- review options to reduce complexity for workloads and processes
   
-This approach ensures the creation and management of environments throughout the software development lifecycle enables:
+## Maximize observability to minimize disruption
 
-- Consistency
-- Repetition
-- Early detection of issues
-  
-## Understand operational health
+Establish observability within your workload and across your cloud infrastructure through robust monitoring and alerting solutions. 
 
-Evaluate operational health through focused and assertive monitoring.
+Enable robust event correlation to allow your teams to take proactive mitigating actions, troubleshoot issues, and efficiently respond to incidents.
 
-Implement systems and processes to monitor the following components:
-  
-- Build and release processes
-- Infrastructure health
-- Application health
-  
-Customer data is critical to understanding the health of a workload and whether the service is meeting the business goals.
+In addition, user data is incredibly valuable when it comes to understanding the user experience and whether your workload meets its business goals. 
 
-## Rehearse recovery and practice failure
+## Minimize the blast radius
 
-Rehearse recovery and practice failure using the following methods:
+Make use of modern architecture patterns and cloud design patterns to create workloads that are designed to anticipate failure, thus minimizing the "blast radius" of an outage or service failure.
 
-- Run disaster recovery (DR) drills on a regular cadence.  
-- Use chaos engineering practices to identify and remediate weak points in application reliability.
-- Rehearse failure to validate the effectiveness of recovery processes and ensure teams are familiar with their responsibilities.
+Modern architecture patterns include:
+ - loosely-coupled architecture
+ - microservices
+ - serverless design
 
-## Embrace continuous operational improvement
+Cloud design patterns include:
+ - circuit breakers
+ - load-leveling
+ - throttling
+ - queuing 
 
-Embrace continuous operational improvement through the following methods:
+In addition, adopting modern deployment practices can help reduce cross-team reliance and help build confidence into automated processes. These practices include:
+ - canary
+ - blue/green deployment
+ - staggered deployment
 
-- Continuously evaluate and refine operational procedures and tasks.
-- Strive to reduce complexity and ambiguity.
-  
-This approach enables an organization to:
+## Minimize time to recovery
 
-- Evolve processes over time.
-- Optimize inefficiencies.
-- Learn from failures.
+Adopt modern engineering practices to swiftly recover in the case of failure. 
 
-## Use loosely coupled architecture
-
-Use loosely coupled architecture to enable teams to independently:
-
-- Test
-- Deploy
-- Update their systems on demand
-  
-Without depending on other teams for:
-  
-- Support
-- Services
-- Resources
-- Approvals
+- Document top system failures
+- Leverage chaos engineering practices to stress test the workload
+- Create clear disaster recovery and remediation plans and rehearse them often 
+- Leverage automation to resolve escalations more easily
+- Document, test, and update your escalation processes frequently
 
 ### Next step
 


### PR DESCRIPTION
(1) update TOC to include monitoring overview page which was orphaned
(2) remove repeated monitoring paragraph on the overview page (this was already covered in monitoring-pipeline)
(3) refresh OpEx overview page and align more with other pillar pages - happy to break this back out from the table format if it does not make sense
(4) update OpEx principles based on discussion with C&L and Marketing